### PR TITLE
Refactoring: move queries to DAO, use of optional and atomic types

### DIFF
--- a/src/main/java/com/cookingchef/controller/LoginController.java
+++ b/src/main/java/com/cookingchef/controller/LoginController.java
@@ -38,7 +38,7 @@ public class LoginController {
 
 		if (user.isPresent()) {
 			showText.setText("Welcome " + user.get().getName());
-			Main.setScene("home");
+			Main.redirect("home");
 		} else {
 			showText.setText("Wrong email or password");
 		}

--- a/src/main/java/com/cookingchef/controller/LoginController.java
+++ b/src/main/java/com/cookingchef/controller/LoginController.java
@@ -1,7 +1,6 @@
 package com.cookingchef.controller;
 
 import com.cookingchef.facade.UserFacade;
-import com.cookingchef.model.User;
 import com.cookingchef.view.Main;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -35,10 +34,10 @@ public class LoginController {
 	@FXML
 	protected void onClickButtonLogin() throws SQLException {
 		UserFacade userFacade = UserFacade.getUserFacade();
-		User user = userFacade.login(this.getEmail(), this.getPassword());
+		var user = userFacade.login(this.getEmail(), this.getPassword());
 
-		if (user != null) {
-			showText.setText("Welcome " + user.getName());
+		if (user.isPresent()) {
+			showText.setText("Welcome " + user.get().getName());
 			Main.setScene("home");
 		} else {
 			showText.setText("Wrong email or password");

--- a/src/main/java/com/cookingchef/dao/PostgresUserDAO.java
+++ b/src/main/java/com/cookingchef/dao/PostgresUserDAO.java
@@ -7,28 +7,55 @@ import com.cookingchef.model.UserDbFields;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
 import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class PostgresUserDAO implements UserDAO {
 
-	private static volatile PostgresUserDAO instance;
+	private static AtomicReference<PostgresUserDAO> instance = new AtomicReference<>();
 
 	private PostgresUserDAO() {
 	}
 
 	public static PostgresUserDAO getPostgresUserDAO() {
-		if (instance == null) {
-			instance = new PostgresUserDAO();
-		}
-		return instance;
+		instance.compareAndSet(null, new PostgresUserDAO());
+		return instance.get();
 	}
 
 	@Override
-	public User getUserByEmailPwd(String email, String password) {
+	public Optional<User> getUserById(int id) throws SQLException {
+		var query = "SELECT * FROM users WHERE id = ?";
+		var conn = ConnectionManager.getConnection();
+
+		try (var stmt = conn.prepareStatement(query)) {
+			stmt.setInt(1, id);
+
+			var rs = stmt.executeQuery();
+
+			if (rs.next()) {
+				return Optional.of(new User(
+						rs.getInt(UserDbFields.ID.value),
+						rs.getString(UserDbFields.NAME.value),
+						rs.getString(UserDbFields.EMAIL.value),
+						rs.getString(UserDbFields.PASSWORD.value),
+						rs.getString(UserDbFields.PHONE.value),
+						rs.getDate(UserDbFields.BIRTHDATE.value),
+						rs.getString(UserDbFields.QUESTION.value),
+						rs.getString(UserDbFields.ANSWER.value),
+						rs.getBoolean(UserDbFields.IS_ADMIN.value)));
+			}
+		}
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<User> getUserByEmailPwd(String email, String password) throws SQLException {
 		var query = "SELECT * FROM users WHERE email = ?";
-		
-		try {
-			var conn = ConnectionManager.getConnection();
-			var stmt = conn.prepareStatement(query);
+		var conn = ConnectionManager.getConnection();
+
+		try (var stmt = conn.prepareStatement(query)) {
 			stmt.setString(1, email);
 
 			var rs = stmt.executeQuery();
@@ -36,7 +63,7 @@ public class PostgresUserDAO implements UserDAO {
 			if (rs.next()) {
 				String hashed = rs.getString(UserDbFields.PASSWORD.value);
 				if (BCrypt.checkpw(password, hashed)) {
-					return new User(
+					return Optional.of(new User(
 							rs.getInt(UserDbFields.ID.value),
 							rs.getString(UserDbFields.NAME.value),
 							rs.getString(UserDbFields.EMAIL.value),
@@ -45,12 +72,89 @@ public class PostgresUserDAO implements UserDAO {
 							rs.getDate(UserDbFields.BIRTHDATE.value),
 							rs.getString(UserDbFields.QUESTION.value),
 							rs.getString(UserDbFields.ANSWER.value),
-							rs.getBoolean(UserDbFields.IS_ADMIN.value));
+							rs.getBoolean(UserDbFields.IS_ADMIN.value)));
 				}
 			}
-		} catch (SQLException e) {
-			e.printStackTrace();
 		}
-		return null;
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<Integer> registerUserInDb(User user) throws SQLException {
+		var query = "INSERT INTO users (name, email, phone, birthdate, question, answer, is_admin, password) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id";
+		var conn = ConnectionManager.getConnection();
+
+		try (var stmt = conn.prepareStatement(query)) {
+			stmt.setString(1, user.getName());
+			stmt.setString(2, user.getEmail());
+			stmt.setString(3, user.getPhone());
+			stmt.setTimestamp(4, new Timestamp(user.getBirthdate().getTime()));
+			stmt.setString(5, user.getQuestion());
+			stmt.setString(6, user.getAnswer());
+			stmt.setBoolean(7, user.getIsAdmin());
+			stmt.setString(8, user.getPassword());
+
+			var rs = stmt.executeQuery();
+			rs.next();
+			return Optional.of(rs.getInt(UserDbFields.ID.value));
+		}
+	}
+
+	@Override
+	public void updateUserInDb(User user) throws SQLException {
+		var query = "UPDATE users SET name=?, email=?, phone=?, birthdate=?, question=?, answer=?, is_admin=?, password=? WHERE id=?";
+		var conn = ConnectionManager.getConnection();
+
+		try (var stmt = conn.prepareStatement(query)) {
+			stmt.setString(1, user.getName());
+			stmt.setString(2, user.getEmail());
+			stmt.setString(3, user.getPhone());
+			stmt.setTimestamp(4, new Timestamp(user.getBirthdate().getTime()));
+			stmt.setString(5, user.getQuestion());
+			stmt.setString(6, user.getAnswer());
+			stmt.setBoolean(7, user.getIsAdmin());
+			stmt.setString(8, user.getPassword());
+			stmt.setInt(9, user.getId());
+
+			stmt.executeUpdate();
+		}
+	}
+
+	@Override
+	public void removeUserFromDb(User user) throws SQLException {
+		var query = "DELETE FROM users WHERE id=?";
+		var conn = ConnectionManager.getConnection();
+
+		try (var stmt = conn.prepareStatement(query)) {
+			stmt.setInt(1, user.getId());
+
+			stmt.executeUpdate();
+		}
+	}
+
+	@Override
+	public List<User> getUsersFromDb() throws SQLException {
+		var query = "SELECT * FROM users";
+		var list = new ArrayList<User>();
+		var conn = ConnectionManager.getConnection();
+
+		try (var stmt = conn.prepareStatement(query)) {
+			var rs = stmt.executeQuery();
+			while (rs.next()) {
+				var user = new User(
+						rs.getInt(UserDbFields.ID.value),
+						rs.getString(UserDbFields.NAME.value),
+						rs.getString(UserDbFields.EMAIL.value),
+						rs.getString(UserDbFields.PASSWORD.value),
+						rs.getString(UserDbFields.PHONE.value),
+						rs.getDate(UserDbFields.BIRTHDATE.value),
+						rs.getString(UserDbFields.QUESTION.value),
+						rs.getString(UserDbFields.ANSWER.value),
+						rs.getBoolean(UserDbFields.IS_ADMIN.value));
+				list.add(user);
+			}
+		}
+
+		return list;
 	}
 }

--- a/src/main/java/com/cookingchef/dao/UserDAO.java
+++ b/src/main/java/com/cookingchef/dao/UserDAO.java
@@ -1,8 +1,60 @@
 package com.cookingchef.dao;
 
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+
 import com.cookingchef.model.User;
 
 public interface UserDAO {
 
-	public abstract User getUserByEmailPwd(String email, String password);
+
+	/**
+	 * Registers a user in the database and returns the user's id if the registration was
+	 * successful, otherwise it returns an empty Optional.
+	 * 
+	 * @param user The user object that you want to register in the database.
+	 * @return An optional integer.
+	 */
+	public Optional<Integer> registerUserInDb(User user) throws SQLException;
+
+	/**
+	 * Updates a user in the database.
+	 * 
+	 * @param user The user object that you want to update in the database.
+	 */
+	public void updateUserInDb(User user) throws SQLException;
+
+	/**
+	 * Removes a user from the database.
+	 * 
+	 * @param user The user object to be removed from the database.
+	 */
+	public void removeUserFromDb(User user) throws SQLException;
+
+	/**
+	 * Fetch this list of users from the database
+	 * 
+	 * @return A list of users from the database.
+	 */
+	public List<User> getUsersFromDb() throws SQLException;
+
+	/**
+	 * Fetch a user from the database by id.
+	 * 
+	 * @param id The id of the user you want to get.
+	 * @return An Optional object that contains a User object.
+	 */
+	public Optional<User> getUserById(int id) throws SQLException;
+
+	/**
+	 * Fetch a user from the database by email and password.
+	 * 
+	 * @param email The email of the user
+	 * @param password The password of the user.
+	 * @return Optional<User>
+	 */
+	public Optional<User> getUserByEmailPwd(String email, String password) throws SQLException;
+
+
 }

--- a/src/main/java/com/cookingchef/dbutils/DbEntity.java
+++ b/src/main/java/com/cookingchef/dbutils/DbEntity.java
@@ -1,14 +1,26 @@
 package com.cookingchef.dbutils;
 
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Optional;
 
 public interface DbEntity {
-  public PreparedStatement create() throws SQLException;
 
-  public PreparedStatement update() throws SQLException;
+  /**
+   * Create an entity in the database and return it's new ID
+   * @return the id of the newly created entity. Returns an empty option if it failed
+   * @throws SQLException
+   */
+  public Optional<Integer> createInDb() throws SQLException;
 
-  public PreparedStatement delete() throws SQLException;
+  /**
+   * Update an entity in the database
+   * @throws SQLException
+   */
+  public void updateInDb() throws SQLException;
 
-  public PreparedStatement read() throws SQLException;
+  /**
+   * Update an entity in the database
+   * @throws SQLException
+   */
+  public void removeFromDb() throws SQLException;
 }

--- a/src/main/java/com/cookingchef/facade/UserFacade.java
+++ b/src/main/java/com/cookingchef/facade/UserFacade.java
@@ -5,9 +5,11 @@ import com.cookingchef.factory.PostgresFactory;
 import com.cookingchef.model.User;
 
 import java.sql.SQLException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class UserFacade {
-	private static volatile UserFacade instance;
+	private static AtomicReference<UserFacade> instance = new AtomicReference<>();
 	private UserDAO userDAO;
 
 	private UserFacade() {
@@ -15,17 +17,12 @@ public class UserFacade {
 		this.userDAO = factory.getUserDAO();
 	}
 
-	public static synchronized UserFacade getUserFacade() {
-		if (instance == null) {
-			instance = new UserFacade();
-
-		}
-		return instance;
+	public static UserFacade getUserFacade() {
+		instance.compareAndSet(null, new UserFacade());
+		return instance.get();
 	}
 
-	public User login(String email,String password) throws SQLException {
-
-
+	public Optional<User> login(String email,String password) throws SQLException {
 		return this.userDAO.getUserByEmailPwd(email,password);
 	}
 }

--- a/src/main/java/com/cookingchef/factory/PostgresFactory.java
+++ b/src/main/java/com/cookingchef/factory/PostgresFactory.java
@@ -1,20 +1,20 @@
 package com.cookingchef.factory;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import com.cookingchef.dao.PostgresUserDAO;
 import com.cookingchef.dao.UserDAO;
 
 public class PostgresFactory implements AbstractFactory {
 
-  private static volatile PostgresFactory instance;
+  private static AtomicReference<PostgresFactory> instance = new AtomicReference<>();
 
   private PostgresFactory() {
   }
 
-  public static synchronized PostgresFactory getPostgresFactory() {
-    if (instance == null) {
-      instance = new PostgresFactory();
-    }
-    return instance;
+  public static PostgresFactory getPostgresFactory() {
+    instance.compareAndSet(null, new PostgresFactory());
+    return instance.get();
   }
   
   @Override

--- a/src/main/java/com/cookingchef/model/User.java
+++ b/src/main/java/com/cookingchef/model/User.java
@@ -1,14 +1,14 @@
 package com.cookingchef.model;
 
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Date;
+import java.util.Optional;
 
-import com.cookingchef.dbutils.ConnectionManager;
 import com.cookingchef.dbutils.DbEntity;
+import com.cookingchef.factory.PostgresFactory;
 
 public class User implements DbEntity {
-	private final int id;
+	private int id;
 	private String name;
 	private String email;
 	private String password;
@@ -17,6 +17,18 @@ public class User implements DbEntity {
 	private String question;
 	private String answer;
 	private Boolean isAdmin;
+
+	public User(String name, String email, String password, String phone, Date birthdate, String question,
+			String answer, Boolean isAdmin) {
+		this.name = name;
+		this.email = email;
+		this.password = password;
+		this.phone = phone;
+		this.birthdate = birthdate;
+		this.question = question;
+		this.answer = answer;
+		this.isAdmin = isAdmin;
+	}
 
 	public User(int id, String name, String email, String password, String phone, Date birthdate, String question,
 			String answer, Boolean isAdmin) {
@@ -156,50 +168,20 @@ public class User implements DbEntity {
 	}
 
 	@Override
-	public PreparedStatement create() throws SQLException {
-		var query = "INSERT INTO users (name, email, phone, birthdate, question, answer, is_admin, password) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id";
-		var conn = ConnectionManager.getConnection();
-		var stmt = conn.prepareStatement(query);
-		stmt.setString(1, this.name);
-		stmt.setString(2, this.email);
-		stmt.setString(3, this.phone);
-		stmt.setTimestamp(4, new java.sql.Timestamp(this.birthdate.getTime()));
-		stmt.setString(5, this.question);
-		stmt.setString(6, this.answer);
-		stmt.setBoolean(7, this.isAdmin);
-		stmt.setString(8, this.password);
-		return stmt;
+	public Optional<Integer> createInDb() throws SQLException {
+		var newId = PostgresFactory.getPostgresFactory().getUserDAO().registerUserInDb(this);
+		if (newId.isPresent())
+			this.id = newId.get();
+		return newId;
 	}
 
 	@Override
-	public PreparedStatement update() throws SQLException {
-		var query = "UPDATE users SET name=?, email=?, phone=?, birthdate=?, question=?, answer=?, is_admin=?, password=? WHERE email=?";
-		var conn = ConnectionManager.getConnection();
-		var stmt = conn.prepareStatement(query);
-		stmt.setString(1, this.name);
-		stmt.setString(2, this.email);
-		stmt.setString(3, this.phone);
-		stmt.setTimestamp(4, new java.sql.Timestamp(this.birthdate.getTime()));
-		stmt.setString(5, this.question);
-		stmt.setString(6, this.answer);
-		stmt.setBoolean(7, this.isAdmin);
-		stmt.setString(8, this.password);
-		stmt.setString(9, this.email);
-		return stmt;
+	public void updateInDb() throws SQLException {
+		PostgresFactory.getPostgresFactory().getUserDAO().updateUserInDb(this);
 	}
 
 	@Override
-	public PreparedStatement delete() throws SQLException {
-		var query = "DELETE FROM users WHERE email=?";
-		var conn = ConnectionManager.getConnection();
-		var stmt = conn.prepareStatement(query);
-		stmt.setString(1, this.email);
-		return stmt;
-	}
-
-	@Override
-	public PreparedStatement read() {
-		// TODO Auto-generated method stub
-		return null;
+	public void removeFromDb() throws SQLException {
+		PostgresFactory.getPostgresFactory().getUserDAO().removeUserFromDb(this);
 	}
 }

--- a/src/main/java/com/cookingchef/view/Main.java
+++ b/src/main/java/com/cookingchef/view/Main.java
@@ -43,7 +43,7 @@ public class Main extends Application {
 		scenes.put(name, pane);
 	}
 
-	public static void setScene(String scene) {
+	public static void redirect(String scene) {
 		root.getChildren().clear();
 		root.getChildren().add(scenes.get(scene));
 	}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -9,7 +9,7 @@ module com.cookingchef {
 	requires org.kordamp.ikonli.javafx;
 	requires org.kordamp.bootstrapfx.core;
 	requires transitive java.sql;
-	requires org.postgresql.jdbc;
+	requires transitive org.postgresql.jdbc;
 	requires spring.security.crypto;
 
 	opens com.cookingchef.view to javafx.fxml;

--- a/src/test/java/com/cookingchef/dbutils/ConnectionManagerTests.java
+++ b/src/test/java/com/cookingchef/dbutils/ConnectionManagerTests.java
@@ -2,8 +2,6 @@ package com.cookingchef.dbutils;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.sql.SQLException;
 
 public class ConnectionManagerTests {
@@ -28,12 +26,10 @@ public class ConnectionManagerTests {
 
   @Test
   void crashWhenWrongConnection() throws SQLException {
-    ConnectionManager.closeConnectionPool();
-    assertThrows(SQLException.class, () -> {
-      ConnectionManager.openConnectionPool("nonExisting", "postgres", "postgres", 0000);
-      ConnectionManager.getConnection();
-    });
-    ConnectionManager.closeConnectionPool();
+    ConnectionManager.setDataSource(null);
+    ConnectionManager.openConnectionPool("nonExisting", "postgres", "postgres", 0000);
+    assert ConnectionManager.getConnection() == null;
+    ConnectionManager.setDataSource(null);
     ConnectionManager.openConnectionPool("postgres", "postgres", "postgres", 5432);
   }
 }

--- a/src/test/java/com/cookingchef/dbutils/LoginTests.java
+++ b/src/test/java/com/cookingchef/dbutils/LoginTests.java
@@ -17,17 +17,16 @@ public class LoginTests {
 
   @Test
   void validateLogin() throws SQLException {
-    var user = new User(-1, "abc", "abc", "$2y$10$QdCYs/d73sagv5Lm13ZJ8.lRAS0lT51fS9TsRa9zO6Kw5QOEIlNe6", "abc",
+    var user = new User("abc", "abc", "$2y$10$QdCYs/d73sagv5Lm13ZJ8.lRAS0lT51fS9TsRa9zO6Kw5QOEIlNe6", "abc",
         Date.from(Instant.now()), "none", "none", false);
-    var stmt = user.create();
-    stmt.executeQuery();
+
+    user.createInDb();
 
     UserFacade userFacade = UserFacade.getUserFacade();
     var abc = userFacade.login("abc", "abc");
 
-    stmt = user.delete();
-    stmt.executeUpdate();
+    user.removeFromDb();
 
-    assert abc != null;
+    assert abc.get() != null;
   }
 }


### PR DESCRIPTION
Some changes :
- As suggested, moved user queries to the DAO and used delegation pattern instead 
- Wherever some results could be null (no results from fetching...), use `Optional` or `List` types instead of null checking
- Switch from `volatile` to `Atomic*` types from `java.util.concurrent.atomic`. Thus `synchronized` is not needed anymore